### PR TITLE
Improved wildcards to find MainActivity and MainApplication

### DIFF
--- a/src/bundle/android/main_activity.js
+++ b/src/bundle/android/main_activity.js
@@ -1,4 +1,4 @@
-const mainActivityDefaultPathPattern = 'app/src/main/java/com/*/MainActivity.java';
+const mainActivityDefaultPathPattern = 'app/src/main/java/**/*/MainActivity.java';
 
 const process = (androidProjectValidPath, payload, strategy) => {
     var mainActivityPathPattern = `${androidProjectValidPath}/${mainActivityDefaultPathPattern}`;

--- a/src/bundle/android/main_app.js
+++ b/src/bundle/android/main_app.js
@@ -1,4 +1,4 @@
-const mainAppDefaultPathPattern = 'app/src/main/java/com/*/MainApplication.java';
+const mainAppDefaultPathPattern = 'app/src/main/java/**/*/MainApplication.java';
 
 const process = (androidProjectValidPath, payload, strategy) => {
     const mainAppPathPattern = `${androidProjectValidPath}/${mainAppDefaultPathPattern}`;


### PR DESCRIPTION
Replaced from `com/*/MainActivity` to `**/*/MainActivity`.
Replaced from `com/*/MainApplication` to `**/*/MainApplication`.

The package does not need to contain "com" in java...